### PR TITLE
feat: switch admin to agent user after signup

### DIFF
--- a/desk/src/pages/desk/Desk.vue
+++ b/desk/src/pages/desk/Desk.vue
@@ -199,7 +199,7 @@ export default {
 			return {
 				method: 'frappedesk.api.setup.initial_agent_setup',
 				onSuccess: (res) => {
-					this.$resources.supportSettings.fetch()
+					this.$router.go()
 				},
 				onError: (err) => {
 					console.log(err)

--- a/frappedesk/api/setup.py
+++ b/frappedesk/api/setup.py
@@ -14,6 +14,10 @@ def initial_agent_setup():
 			agent.insert()
 			support_settings_doc.initial_agent_set = True
 			support_settings_doc.save()
+
+			if frappe.session.user == "Administrator":
+				frappe.local.login_manager.login_as(agent.user)
+			
 			return
 
 @frappe.whitelist()
@@ -56,9 +60,6 @@ def create_initial_demo_ticket():
 			new_ticket_doc.insert()
 
 			create_communication_via_contact(new_ticket_doc.name, new_ticket_doc.description)
-
-			support_settings_doc.initial_demo_ticket_created = True
-			support_settings_doc.save()
-			return
-	else:
-		return
+	support_settings_doc.initial_demo_ticket_created = True
+	support_settings_doc.save()
+	return


### PR DESCRIPTION
After creating the site and completing the initial setup the session user "Admininstrator" is switched to the newly created Agent.