### PR TITLE
fix: navbar items issue in support portal

### DIFF
--- a/desk/src/components/portal/NavBar.vue
+++ b/desk/src/components/portal/NavBar.vue
@@ -9,7 +9,15 @@
 				</div>
 				<div class="flex space-x-8 text-[14px] text-[#4C5A67] items-center">
 					<div v-for="item in navbarItems" :key="item.label">
-						<a :href="item.url" class="hover:text-[#2490ef]">{{ item.label }}</a>
+						<Dropdown v-if="item.children.length > 0" :options="item.children">
+							<template v-slot="{ toggleDropdown }">
+								<div class="flex flex-row space-x-2 items-center cursor-pointer" @click="toggleDropdown">
+									<span class="hover:text-[#2490ef]">{{ item.label }}</span>
+									<FeatherIcon name="chevron-down" class="h-4 w-4 stroke-black"/>
+								</div>
+							</template>
+						</Dropdown>
+						<a v-else :href="item.url" class="hover:text-[#2490ef]">{{ item.label }}</a>
 					</div>
 					<Dropdown
 						placement="right"
@@ -33,7 +41,7 @@
 	</div>
 </template>
 <script>
-import { Dropdown } from 'frappe-ui'
+import { Dropdown, FeatherIcon } from 'frappe-ui'
 import CustomIcons from '@/components/desk/global/CustomIcons.vue'
 import CustomAvatar from '../global/CustomAvatar.vue'
 import { inject } from 'vue'
@@ -41,10 +49,11 @@ import { inject } from 'vue'
 export default {
 	name: 'NavBar',
 	components: {
-		CustomIcons,
-		CustomAvatar,
-		Dropdown
-	},
+	CustomIcons,
+	CustomAvatar,
+	Dropdown,
+	FeatherIcon
+},
 	setup() {
 		const user = inject('user')
 		const ticketTemplates = inject('ticketTemplates')
@@ -61,7 +70,26 @@ export default {
 	},
 	computed: {
 		navbarItems() {
-			return this.$resources.navbarItems.data || []
+			const parentItems = []
+			if (this.$resources.navbarItems.data) {
+				this.$resources.navbarItems.data.forEach(item => {
+					if (!item.parent_label) {
+						item.children = []
+						parentItems.push(item)
+					}
+				})
+				this.$resources.navbarItems.data.forEach(item => {
+					if (item.parent_label) {
+						item.handler = () => {
+							window.location.href = item.url
+						}
+						parentItems.find(x => x.label === item.parent_label).children.push(item)
+					}
+				})
+				return parentItems
+			} else {
+				return parentItems
+			}
 		},
 		profileOptions() {
 			return [


### PR DESCRIPTION
#### Before
The top navbar items did not consider parent/children layout, it showed all the items in navbar table

#### After
The child items in the navbar table are shown in the dropdown list of the parent navbar item