### PR TITLE
fix: text formating issue in comments

### DIFF
--- a/desk/src/components/desk/ticket/CommentCard.vue
+++ b/desk/src/components/desk/ticket/CommentCard.vue
@@ -9,7 +9,7 @@
 		</div>
 		<div class="pl-[32px] pt-[6px]">
 			<div class="flex flex-col">
-				<div class="ql-container text-[13px] text-gray-700" v-html="cleanedMessage"></div>
+				<div class="prose prose-p:my-1 text-[13px] text-gray-700" v-html="cleanedMessage"></div>
 			</div>
 		</div>
 	</div>

--- a/desk/src/components/global/CustomTextEditor.vue
+++ b/desk/src/components/global/CustomTextEditor.vue
@@ -8,7 +8,7 @@
 					class="overflow-y-scroll"
 					:class="editorClasses"
 					:content="content"
-					editor-class="w-full"
+					editor-class="w-full text-[13px]"
 					:placeholder="placeholder"
 					:editable="true"
 					@change="(val) => {


### PR DESCRIPTION
Issue: Text formatting did not reflect after submitting the comment, also the text size in text editor and the conversation / comment cards where different

Comment typed in the text editor
<img width="674" alt="image" src="https://user-images.githubusercontent.com/22856401/185095634-a6a7fc44-085f-4bc7-8c8e-70be8bd20260.png">

### Before
Comment Card
<img width="674" alt="image" src="https://user-images.githubusercontent.com/22856401/185095372-94dfa2c3-41d8-4ff1-aeab-c22c72baf962.png">

Text Editor
<img width="674" alt="image" src="https://user-images.githubusercontent.com/22856401/185096290-420155e3-9fff-436a-b570-a397681f4100.png">

### After
Comment Card
<img width="674" alt="image" src="https://user-images.githubusercontent.com/22856401/185095448-42967391-c7d2-4fcc-8218-1726710dd62d.png">

Text Editor (_text size changed_)
<img width="674" alt="image" src="https://user-images.githubusercontent.com/22856401/185096236-b13d9e34-b603-4812-942d-e89ab6bf30e9.png">

