### PR TITLE
fix: service level agreement not set to ticket issue

### DIFF
--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
@@ -107,7 +107,7 @@
    "label": "Service Level Agreements"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "track_service_level_agreement",
    "fieldtype": "Check",
    "label": "Track Service Level Agreement"
@@ -152,7 +152,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-08-16 20:36:52.875181",
+ "modified": "2022-08-17 22:24:32.937552",
  "modified_by": "Administrator",
  "module": "FrappeDesk",
  "name": "Frappe Desk Settings",

--- a/frappedesk/patches.txt
+++ b/frappedesk/patches.txt
@@ -15,3 +15,4 @@ frappedesk.patches.refactor_ticket_activity_grammar
 frappedesk.patches.add_default_assignment_rule
 frappedesk.patches.add_support_redirect_to_tickets
 frappedesk.patches.set_initial_order_for_articles_and_categories
+frappedesk.patches.mark_track_service_level_agreement_true

--- a/frappedesk/patches/mark_track_service_level_agreement_true.py
+++ b/frappedesk/patches/mark_track_service_level_agreement_true.py
@@ -1,0 +1,6 @@
+import frappe
+from frappedesk.setup.install import enable_track_service_level_agreement_in_support_settings
+
+def execute():
+    enable_track_service_level_agreement_in_support_settings()
+    


### PR DESCRIPTION
**Issue**: the default value for track_service_level_agreement was set as 0. after renaming Support Settings to Frappe Desk Settings, the value for track_service_level_agreement got changed from 1 to 0

**Fix**: add patch to change track_service_level_agreement back to 1, and mark track_service_level_agreement as default 1