### PR TITLE
fix: remove ellipses from email in contact info

### DIFF
--- a/desk/src/components/desk/ticket/InfoPanel.vue
+++ b/desk/src/components/desk/ticket/InfoPanel.vue
@@ -24,10 +24,10 @@
 								<a :title="phone_no.phone" class="text-gray-700 text-base">{{ phone_no.phone }}</a>
 							</div>
 						</div>
-						<div v-if="ticket.contact.email_ids.length > 0" class="flex space-x-[12px] items-center">
-							<FeatherIcon name="mail" class="stroke-gray-500" style="width: 15px;" />
-							<div class="space-y-1 max-w-[173px]" v-for="email in ticket.contact.email_ids" :key="email">
-								<div :title="email.email_id" class="truncate text-gray-700 text-base">
+						<div v-if="ticket.contact.email_ids.length > 0" class="flex space-x-[12px]">
+							<FeatherIcon name="mail" class="stroke-gray-500 mt-[2.5px]" style="width: 15px; height: 15px;" />
+							<div class="space-y-1 max-w-[173px] break-words" v-for="email in ticket.contact.email_ids" :key="email">
+								<div :title="email.email_id" class="text-gray-700 text-base">
 									<a :title="email.email_id">{{ email.email_id }}</a>
 								</div>
 							</div>


### PR DESCRIPTION
Resolves #715 

### Before
<img width="278" alt="image" src="https://user-images.githubusercontent.com/22856401/190450458-ce26f94b-4644-4c2d-ba6f-a1e35a3f5768.png">

### After
<img width="278" alt="image" src="https://user-images.githubusercontent.com/22856401/190450560-bf8fbf80-a29c-46bf-96fe-f6c5a1b1eff1.png">
