### PR TITLE
feat: canned response

### DIFF
--- a/desk/src/components/desk/global/AddNewCannedResponsesDialog.vue
+++ b/desk/src/components/desk/global/AddNewCannedResponsesDialog.vue
@@ -1,0 +1,152 @@
+<template>
+	<div>
+		<Dialog
+			:options="{ title: 'New canned response' }"
+			:show="show"
+			@close="close()"
+		>
+			<template #body-content>
+				<div class="space-y-6">
+					<form
+						@submit.prevent="onSubmit"
+						class="flex flex-row space-x-5 items-center"
+					>
+						<Input
+							id="searchInput"
+							class="w-full"
+							type="text"
+							placeholder="Enter Title"
+							@input="(val) => {
+								tempNewTitle=val
+							}"
+						/>
+					</form>
+				</div>
+				<div>
+					<CustomTextEditor
+
+						:show="true"
+						ref="contentEditor"
+						@click="$refs.contentEditor.focusEditor()"
+						@change="(res)=>{
+							tempNewMessage=res
+						}"
+						editorClasses="w-full p-[12px] bg-gray-100 min-h-[180px] max-h-[500px] text-[16px]"
+						class="rounded-[8px]"
+					>
+					<template #top-section="{ editor }">
+						<div class="flex flex-col">
+							<div
+							class="block mb-2 text-sm leading-4 text-gray-700"
+							>
+							Message
+							</div>
+							<div class="flex flex-row items-center space-x-1.5 p-1.5 rounded-t-[8px] border bg-gray-50">
+								<div
+									v-for="item in [
+										'bold',
+										'italic',
+										'|',
+										'quote',
+										'code',
+										'|',
+										'numbered-list',
+										'bullet-list',
+										'left-align',
+										'center-align',
+										'right-align',
+									]"
+									:key="item"
+								>
+								<TextEditorMenuItem
+									:item="item"
+									:editor="editor"
+								/>
+
+								</div>
+
+							</div>
+
+						</div>
+
+					</template>
+					</CustomTextEditor>
+				</div>
+			</template>
+			<template #actions>
+				<Button
+					appearance="primary"
+					@click="addResponse()"
+					>Add Response</Button
+				>
+			</template>
+		</Dialog>
+	</div>
+</template>
+
+<script>
+import { Dialog, Input, FeatherIcon } from "frappe-ui"
+import { ref } from "@vue/reactivity"
+import CustomTextEditor from "@/components/global/CustomTextEditor.vue"
+import TextEditorMenuItem from "@/components/global/TextEditorMenuItem.vue"
+export default {
+	name: "AddNewCannedResponsesDialog",
+	props: ["show"],
+	components: {
+		Dialog,
+		Input,
+		FeatherIcon,
+		CustomTextEditor,
+		TextEditorMenuItem
+	},
+	setup() {
+		const tempNewTitle=ref("")
+		const tempNewMessage=ref("")
+		const responseInputErrors=ref("")
+		return {
+			tempNewMessage,
+			tempNewTitle,
+			responseInputErrors
+		}
+	},
+	methods: {
+		close() {
+			this.tempNewTitle = ""
+			this.tempNewMessage = ""
+			this.$emit("close")
+		},
+		addResponse(){
+			const inputParams={
+				title:this.tempNewTitle,
+				message:this.tempNewMessage
+			}
+			this.$resources.newResponse.submit({
+				doc:{
+					doctype:"Canned Response",
+					...inputParams,
+				}
+			})
+		}
+	},
+	resources: {
+		newResponse(){
+			return {
+				method:"frappe.client.insert",
+				onSuccess: (doc)=>{
+					this.$router.push(
+						`/frappedesk/settings/canned_responses/${doc.name}`
+					)
+				},
+				onError: (err)=>{
+					this.$toast({
+						title: "Error while creating canned response",
+						text: err,
+						customIcon: "circle-fail",
+						appearance: "danger",
+					})
+				}
+			}
+		}
+	},
+}
+</script>

--- a/desk/src/components/desk/global/CannedResponsesDialog.vue
+++ b/desk/src/components/desk/global/CannedResponsesDialog.vue
@@ -1,0 +1,111 @@
+<template>
+    <div>
+        <Dialog :options="{ title: 'Canned Responses'}"
+                :show="show"
+                @close="close()"
+        >
+        <template #body-content>
+            <div class="space-y-6 flex flex-row">
+                <Input 
+                    v-model="search"
+                    id="searchInput"
+                    class="w-full"
+                    type="text"
+                    placeholder="Search for response"
+                    @input="getCannedResponses"
+                />
+            </div>
+            <div class="divide-y divide-slate-200 ">
+            <div v-for="item in this.cannedResponses" class="relative py-1">
+                <CustomIcons
+                    name="add-new"
+                    class="h-7 w-7 rounded p-1 mb-4 absolute right-0"
+                    role="button"
+                    
+                    @click="addMessage(item);emitMessage();close()"
+
+                />
+            <Accordion class="my-2">
+            <template v-slot:title>
+                <span class="font-medium text-lg ">{{item.title}}</span>
+            </template>
+            <template v-slot:content>
+                <div v-html="item.message" class="font-normal text-lg text-grey ml-5">
+                    
+                </div>
+                    
+            </template>
+
+        </Accordion>
+    </div>
+</div>
+        </template>
+            
+        </Dialog>
+    </div>
+</template>
+
+<script>
+import { Dialog,FeatherIcon, Input } from "frappe-ui"
+import Accordion from "@/components/global/Accordion.vue"
+import CustomIcons from "@/components/desk/global/CustomIcons.vue"
+import {ref,computed,provide} from "vue"
+export default{
+    name:"CannedResponsesDialog",
+    props:["show"],
+    components:{
+        Dialog,
+        FeatherIcon,
+        Accordion,
+        CustomIcons
+    },
+    setup (){
+        const listManager=ref([])
+        const tempMessage=ref("")
+        provide("tempMessage",tempMessage)
+        return {
+            listManager,
+            tempMessage
+        }
+    },
+    data(){
+        return {
+            cannedResponses:[]
+        }
+    },
+    methods:{
+        close(){
+            this.$emit("close")
+            this.$emit('messageVal',this.$refs.tempMessage)
+        },
+        emitMessage(){
+            this.$emit('messageVal',this.$refs.tempMessage)
+        },
+        addMessage(item){
+            this.$refs.tempMessage=item.message
+        },
+        getCannedResponses(event){
+    
+            let title = event
+            this.$resources.list.fetch({
+                    title:title
+                })
+        }         
+    },
+    resources:{
+        list(){
+            
+           return {
+            method:"frappedesk.api.cannedResponse.get_canned_response",
+            onSuccess(val){
+                this.cannedResponses=val
+                return this.cannedResponses
+            }   
+            }
+        }
+    },
+    beforeMount(){
+        this.getCannedResponses()
+    }
+}
+</script>

--- a/desk/src/components/desk/global/CustomIcons.vue
+++ b/desk/src/components/desk/global/CustomIcons.vue
@@ -1220,6 +1220,69 @@
 			/>
 		</svg>
 		<svg
+			v-if="this.name=='add-response'"
+			:class="this.class" 
+			:width="this.width" 
+			:height="this.height" 
+			viewBox="0 0 17 17" 
+			fill="none" 
+			xmlns="http://www.w3.org/2000/svg">
+			<path 
+				d="M10.0783 2.05H4.97627L4.00006 2.05C2.61935 2.05 1.50006 3.16929 1.50006 4.55V8.32288V8.32289L1.50003 10.121C1.50001 11.5018 2.61931 12.6211 4.00003 12.6211H7.87765L7.87765 13.8306C7.87765 14.6723 8.85393 15.1375 9.50759 14.6073L11.8186 12.7328C11.9077 12.6605 12.0189 12.6211 12.1336 12.6211H12.7552C14.1359 12.6211 15.2552 11.5018 15.2552 10.1211V8.32289V4.54999C15.2552 3.16928 14.1359 2.04999 12.7552 2.04999L10.0783 2.05Z" 
+				stroke="#1F272E" 
+				stroke-miterlimit="10" 
+				stroke-linecap="square"/>
+			<path 
+				d="M8.72406 10.2L7.95645 9.69359L9.28934 7.65922H7.45026C7.34116 7.659 7.23577 7.61848 7.15378 7.5453C7.07179 7.47212 7.01851 7.37113 7.004 7.26109C6.9895 7.15104 7.0147 7.03939 7.07487 6.9468L8.87594 4.20001L9.64355 4.7236L8.28967 6.74073H10.1497C10.2588 6.74105 10.3642 6.78147 10.4462 6.85465C10.5282 6.92793 10.5815 7.02881 10.596 7.13886C10.6105 7.2489 10.5853 7.36055 10.5251 7.45325L8.72406 10.2Z" 
+				fill="black"/>
+		</svg>
+		<svg
+			v-if="this.name=='chevron-down-accordion'"
+          	class="w-3 transition-all duration-200 transform"
+          	:class="this.class"
+			:width="this.width"
+			:height="this.height"
+          	fill="none"
+          	stroke="currentColor"
+          	xmlns="http://www.w3.org/2000/svg"
+          	viewBox="0 0 16 10"
+          	aria-hidden="true"
+        >
+          <path
+            d="M15 1.2l-7 7-7-7"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+		<svg
+			v-if="this.name=='add-new'"
+			:class="this.class" 
+			:width="this.width" 
+			:height="this.height" 
+			viewBox="0 0 24 24" 
+			fill="none" 
+			xmlns="http://www.w3.org/2000/svg">
+			<rect 
+				:width="24" 
+				:height="24" 
+				rx="6" 
+				fill="#F4F5F6"/>
+				<path 
+				d="M12 8V16" 
+				stroke="#1F272E" 
+				stroke-miterlimit="10" 
+				stroke-linecap="round" 
+				stroke-linejoin="round"/>
+				<path 
+				d="M8 12H16" 
+				stroke="#1F272E" 
+				stroke-miterlimit="10" 
+				stroke-linecap="round" 
+				stroke-linejoin="round"/>
+		</svg>
+
+		<svg
 			v-if="this.name == 'underline'"
 			:class="this.class"
 			:width="this.width"

--- a/desk/src/components/desk/settings/SettingsSideBarMenu.vue
+++ b/desk/src/components/desk/settings/SettingsSideBarMenu.vue
@@ -33,6 +33,11 @@ export default {
 					route: "/frappedesk/settings/sla",
 				},
 				{
+					label: "Canned Responses",
+					pageName: "CannedResponses",
+					route: "/frappedesk/settings/canned_response",
+				},	
+				{
 					label: "Email Accounts",
 					pageName: "Emails",
 					route: "/frappedesk/settings/emails",

--- a/desk/src/components/desk/settings/SettingsTopPanel.vue
+++ b/desk/src/components/desk/settings/SettingsTopPanel.vue
@@ -53,6 +53,16 @@ export default {
 					this.$event.emit("delete-selected-agents")
 				}),
 			],
+			CannedResponses: [
+				new Action("Add Response", "plus", "primary", () => {
+					this.$event.emit("show-new-canned_response-dialog")
+				}),
+			],
+			"Canned Responses Bulk": [
+				new Action("Delete", "", "secondary", () => {
+					this.$event.emit("delete-selected-canned_responses")
+				}),
+			],
 			"Support Policies": [
 				new Action("New Policy", "plus", "primary", () => {
 					this.$router.push({ name: "NewSlaPolicy" })

--- a/desk/src/components/desk/settings/canned_responses/CannedResponseInfo.vue
+++ b/desk/src/components/desk/settings/canned_responses/CannedResponseInfo.vue
@@ -1,0 +1,174 @@
+<template>
+	<div class="min-w-[490px] px-[24px] py-[10px]">
+		<div class="shrink-0 h-[72px] py-[22px] flow-root px-[16px]">
+			<div class="float-left">
+				<router-link
+					:to="`/frappedesk/settings/canned_response`"
+					class="my-1 text-[12px] text-gray-600 stroke-gray-600 flex flex-row items-center space-x-1 hover:text-gray-700 hover:stroke-gray-700 select-none"
+					role="button"
+				>
+				<FeatherIcon name="arrow-left" class="w-[13px] h-[13px]" />
+				<div>
+					Back to response list
+				</div>
+				</router-link>
+
+			</div>
+			<div class="float-right">
+				<div v-if="!editMode" class="flex flex-row space-x-2">
+					<Button
+					appearance="secondary"
+					@click="()=>{
+						editMode = true
+						newAResponseTempValues={
+							title: cannedResponseDoc.title,
+							message:cannedResponseDoc.message
+						}
+					}"					
+					>Edit</Button>
+				</div>
+				<div v-else class="flex flex-row space-x-2">
+					<Button
+					appearance="secondary"
+					@click="()=>{
+						this.$router.go()
+					}"
+					>
+					Cancel
+					</Button>
+					<Button 
+					appearance="primary" @click="saveResponse()"
+					>
+					Save
+					</Button>
+				</div>
+			</div>
+		</div>
+		<div class="flex flex-row space-x-[24px] h-full border-t px-[16px] py-[22px]">
+
+			<ResponseTitleAndMessage
+				class="grow"
+				:title="values?.cannedResponseName"
+				:message="values?.message"
+				:editable="editMode"
+				:responseResource="$resources.cannedResponse"
+			/>
+		</div>
+	</div>
+</template>
+<script>
+import { ref,provide } from "vue"
+import { FeatherIcon, Input } from "frappe-ui"
+import ResponseTitleAndMessage from "@/components/desk/settings/canned_responses/ResponseTitleAndMessage.vue"
+
+export default {
+	name: "CannedResponseInfo",
+	props: ["canned_response"],
+	components: {
+		FeatherIcon,
+		Input,
+		ResponseTitleAndMessage
+	},
+	setup(props) {
+		const editingName = ref(false)
+		const newResponseTempValues = ref({})
+		const updateNewResponseInput = ref((input)=>{
+			newResponseTempValues.value[input.field] = input.value
+		})
+		provide("updateNewResponseInput", updateNewResponseInput)
+		provide("newResponseTempValues", newResponseTempValues)
+		const saveResponseTitleAndMessage=ref(()=>{})
+		provide("saveResponseTitleAndMessage", saveResponseTitleAndMessage)
+		const tempCannedResponseName = ref("")
+		const updatingValues = ref(false)
+		const editMode=ref(!props.canned_response)
+		provide("editMode", editMode)
+	
+		
+		return {
+			editingName,
+			tempCannedResponseName,
+			updatingValues,
+			editMode,
+			newResponseTempValues,
+			saveResponseTitleAndMessage
+		}
+	},
+	computed: {
+		cannedResponseDoc() {
+			return this.$resources.cannedResponse.doc || null
+		},
+		values() {
+			if (this.updatingValues) {
+				return this.values || null
+			}
+			return {
+				cannedResponseName: this.cannedResponseDoc?.title || null,
+				message: this.cannedResponseDoc?.message || null
+			}
+		},
+	},
+	deactivated() {
+		this.resetForm()
+	},
+	resources: {
+		cannedResponse() {
+			return {
+				type: "document",
+				doctype: "Canned Response",
+				name: this.canned_response,
+				setValue: {
+					onSuccess: () => {
+						this.$toast({
+							title: "Canned Response Updated.",
+							customIcon: "circle-check",
+							appearance: "success",
+						})
+					},
+					onError:(err)=>{
+						this.$toast({
+							title: "Error while updating canned response",
+							text: err,
+							customIcon: "circle-fail",
+							appearance: "danger",
+						})
+					}
+				},
+			}
+		},
+	},
+	methods: {
+		resetForm() {
+			this.editingName = false
+			this.tempCannedResponseName = this.values.cannedResponseName
+		},
+		save() {
+			this.updatingValues = true
+			const newValues = this.values
+			this.$resources.user.setValue
+				.submit({
+					title: newValues.title,
+					message: newValues.message,
+				})
+				.then(() => {
+					this.$resources.cannedResponse.setValue.submit({
+						title: this.tempCannedResponseName,
+					})
+				})
+		},
+		saveResponse(){
+			const inputParams={
+				title:this.newResponseTempValues.title,
+				message:this.newResponseTempValues.message
+			}
+			this.$resources.cannedResponse.setValue.submit({
+				...inputParams
+			})
+			this.editMode = false
+		},
+		cancel() {
+			this.$router.go()
+		},
+	},
+}
+</script>

--- a/desk/src/components/desk/settings/canned_responses/CannedResponseList.vue
+++ b/desk/src/components/desk/settings/canned_responses/CannedResponseList.vue
@@ -1,0 +1,87 @@
+<template>
+	<div>
+		<div
+			class="bg-[#F7F7F7] group flex items-center text-base font-medium text-gray-500 py-[10px] px-[11px] rounded-[6px] select-none"
+		>
+			<div class="w-[37px] h-[14px]">
+				<Input
+					type="checkbox"
+					@click="manager.selectAll()"
+					:checked="manager.allItemsSelected"
+					role="button"
+				/>
+			</div>
+			<div class="flex flex-row items-center group w-full">
+				<div class="sm:w-10/12">Title</div>
+				<div class="sm:w-2/12">Author</div>
+				<div class="sm:w-2/12"></div>
+				
+			</div>
+		</div>
+		<div
+			id="rows"
+			class="flex flex-col space-y-2 overflow-scroll"
+			:style="{
+				height: viewportWidth > 768 ? 'calc(100vh - 120px)' : null,
+			}"
+		>
+			<div v-if="!manager.loading">
+				<div v-if="manager.list.length > 0">
+					<div
+						v-for="(canned_response, index) in manager.list"
+						:key="canned_response.name"
+					>
+						<CannedResponseListItem
+							:class="
+								index == 0 ? 'mt-[9px] mb-[2px]' : 'my-[2px]'
+							"
+							:canned_response="canned_response"
+							@toggle-select="manager.select(canned_response)"
+							:selected="manager.itemSelected(canned_response)"
+						/>
+					</div>
+				</div>
+				<div v-else>
+					<div class="grid place-content-center h-48 w-full">
+						<div>
+							<CustomIcons
+								name="empty-list"
+								class="h-12 w-12 mx-auto mb-2"
+							/>
+							<div class="text-gray-500 mb-2">
+								No canned response found
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="pb-2">
+				<Button v-if="manager.hasNextPage" @click="manager.nextPage()">
+					Load More
+				</Button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { inject } from "vue"
+import { Input } from "frappe-ui"
+import CannedResponseListItem from "@/components/desk/settings/canned_responses/CannedResponseListItem.vue"
+import CustomIcons from "@/components/desk/global/CustomIcons.vue"
+export default {
+	name: "CannedResponseList",
+	props: ["manager"],
+	components: {
+		CannedResponseListItem,
+		CustomIcons,
+		Input,
+	},
+	setup() {
+		const viewportWidth = inject("viewportWidth")
+		return {
+			viewportWidth,
+		}
+	},
+}
+</script>

--- a/desk/src/components/desk/settings/canned_responses/CannedResponseListItem.vue
+++ b/desk/src/components/desk/settings/canned_responses/CannedResponseListItem.vue
@@ -1,0 +1,45 @@
+<template>
+	<div
+		class="block select-none rounded-[6px] py-[7px] px-[11px]"
+		:class="selected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'"
+	>
+		<div v-if="canned_response" role="button" class="flex items-center text-base">
+			<div class="w-[37px] h-[14px] flex items-center">
+				<Input
+					type="checkbox"
+					@click="$emit('toggleSelect')"
+					:checked="selected"
+					role="button"
+				/>
+			</div>
+			<router-link
+				:to="`/frappedesk/settings/canned_responses/${canned_response.name}`"
+				class="w-full group flex items-center"
+			>
+				<div class="sm:w-10/12 truncate pr-10">
+					{{ canned_response.title }}
+				</div>
+				<div class="sm:w-2/12 truncate pr-10">
+					{{ canned_response.owner }}
+				</div>
+				<div class="sm:w-2/12 truncate">
+
+				</div>
+			</router-link>
+		</div>
+	</div>
+</template>
+
+<script>
+import { Input, FeatherIcon } from "frappe-ui"
+import Badge from "frappe-ui/src/components/Badge.vue"
+export default {
+	name: "CannedResponseListItem",
+	props: ["canned_response", "selected"],
+	components: {
+		Input,
+		FeatherIcon,
+		Badge,
+	},
+}
+</script>

--- a/desk/src/components/desk/settings/canned_responses/ResponseTitleAndMessage.vue
+++ b/desk/src/components/desk/settings/canned_responses/ResponseTitleAndMessage.vue
@@ -1,0 +1,133 @@
+<template>
+    <div>
+    <div 
+        v-if="!editable"
+        class="flex flex-col space-y-[16px] rounded-[8px] border shadow-sm p-[32px]"
+    >
+    <div
+        class="font-semibold text-[24px] prose prose-p:my-1 border-b pb-[16px] mb-[10px]"
+    >
+        {{title}}
+
+    </div>
+    <div
+        class="overflow-y-scroll"
+        style="
+            min-height: calc(100vh - 500px);
+            max-height: calc(100vh - 245px);
+        "
+        v-html="message"
+    >
+    </div>
+        
+    </div>
+    <div v-else>
+        <div class="flex flex-col space-y-[16px] h-full">
+            <div>
+                <input
+                    class="border-gray-400 placeholder-gray-500 form-input block w-full"
+                    label="Title"
+                    type="text"
+                    :value="title"
+                    @input="(val)=>{
+                        tempNewTitle=val
+                    }"
+                />
+            </div>
+            <div>
+                <CustomTextEditor 
+                :show="true"
+                ref="contentEditor"
+                @click="$refs.contentEditor.focusEditor()"
+                :content="message"
+                @change="(val)=>{
+                    tempNewMessage=val
+                }"
+                editorClasses="w-full p-[12px] bg-gray-100 min-h-[180px] max-h-[500px] text-[16px]"
+                class="rounded-[8px]"            
+                >
+                <template #top-section="{ editor }">
+                    <div class="flex flex-col">
+                        <div class="block mb-2 text-sm leading-4 text-gray-700">
+                            Message
+                        </div>
+                        <div class="flex flex-row items-center space-x-1.5 p-1.5 rounded-t-[8px] border bg-gray-50">
+                            <div 
+                                v-for="item in [
+                                    'bold',
+									'italic',
+									'|',
+									'quote',
+									'code',
+									'|',
+									'numbered-list',
+									'bullet-list',
+									'left-align',
+									'center-align',
+									'right-align',
+                                ]"
+                                :key="item"
+                            >
+                            <TextEditorMenuItem
+                                :item="item"
+                                :editor="editor"
+                            />
+                            </div>
+                        </div>
+                    </div>
+                </template>
+                </CustomTextEditor>
+            </div>
+        </div>
+    </div>
+    </div>
+</template>
+
+<script>
+import CustomTextEditor from "@/components/global/CustomTextEditor.vue"
+import TextEditorMenuItem from "@/components/global/TextEditorMenuItem.vue"
+import { ref, inject } from "vue"
+export default {
+	name: "ResponseTitleAndMessage",
+	props: ["title", "message", "editable", "responseResource"],
+	components: {
+		CustomTextEditor,
+		TextEditorMenuItem,
+	},
+	mounted() {
+		this.saveResponseTitleAndMessage = this.save
+	},
+	watch: {
+		tempNewTitle(val) {
+			this.updateNewResponseInput({ field: "title", value: val })
+		},
+		tempNewMessage(val) {
+			this.updateNewResponseInput({ field: "message", value: val })
+		},
+	},
+	setup(props) {
+		const tempNewTitle = ref(props.title)
+		const tempNewMessage = ref(props.message)
+		const editMode = inject("editMode")
+		const updateNewResponseInput = inject("updateNewResponseInput")
+		const saveResponseTitleAndMessage = inject("saveResponseTitleAndMessage")
+		return {
+			tempNewTitle,
+			tempNewMessage,
+			editMode,
+			updateNewResponseInput,
+			saveResponseTitleAndMessage,
+		}
+	},
+	methods: {
+		save() {
+			this.responseResource.setValue.submit({
+				title: this.tempNewTitle,
+				message: this.tempNewMessage,
+			})
+			this.editMode = false
+		},
+        
+	},
+}
+</script>

--- a/desk/src/components/global/Accordion.vue
+++ b/desk/src/components/global/Accordion.vue
@@ -1,0 +1,44 @@
+<template>
+    <div>
+      <button 
+        @click="toggleAccordion()" 
+        class="flex items-center space-x-3" 
+        :aria-expanded="isOpen"
+        :aria-controls="`collapse${_uid}`"
+      >
+      <CustomIcons
+          :class="{
+            'rotate-180': isOpen,
+            'rotate-0': !isOpen,
+          }"
+          name="chevron-down-accordion"
+        />
+        <slot name="title"/>
+        
+      </button>
+      
+      <div v-show="isOpen" :id="`collapse${_uid}`">
+        <slot name="content"/>
+      </div>
+    </div>
+  </template>
+
+<script>
+import CustomIcons from "@/components/desk/global/CustomIcons.vue"
+export default {
+    name:"Accordion",
+    components:{
+      CustomIcons
+    },
+  data() {
+    return {
+      isOpen: false,
+    };
+  },
+  methods: {
+    toggleAccordion() {
+      this.isOpen = !this.isOpen;
+    },
+  },
+};
+</script>

--- a/desk/src/pages/desk/Ticket.vue
+++ b/desk/src/pages/desk/Ticket.vue
@@ -305,6 +305,21 @@
 													$refs.replyEditor.insertLink
 												"
 											/>
+											<CustomIcons	
+												name="add-response"
+												class="h-7 w-7 rounded p-1"
+												role="button"
+												@click="()=>{
+													showCannedResponsesDialog=true
+												}"
+											/>
+											<CannedResponsesDialog
+												:show="showCannedResponsesDialog"
+												@messageVal="getMessage($event)"
+												@close="()=>{
+													showCannedResponsesDialog=false
+												}"					
+											/>
 										</div>
 										<div class="grow flex flex-row-reverse">
 											<FeatherIcon
@@ -370,6 +385,7 @@ import ActionPanel from "@/components/desk/ticket/ActionPanel.vue"
 import CustomIcons from "@/components/desk/global/CustomIcons.vue"
 import TextEditorMenuItem from "@/components/global/TextEditorMenuItem.vue"
 import CustomerSatisfactionFeedback from "@/components/portal/ticket/CustomerSatisfactionFeedback.vue"
+import CannedResponsesDialog from "@/components/desk/global/CannedResponsesDialog.vue"
 import { inject, ref } from "vue"
 
 export default {
@@ -390,6 +406,7 @@ export default {
 		CustomIcons,
 		CustomerSatisfactionFeedback,
 		TextEditorMenuItem,
+		CannedResponsesDialog
 	},
 	data() {
 		return {
@@ -417,6 +434,8 @@ export default {
 
 		const sideBarFilterMap = inject("sideBarFilterMap")
 		const ticketSideBarFilter = inject("ticketSideBarFilter")
+		const showCannedResponsesDialog=ref(false)
+		const tempMessage=ref("")
 
 		return {
 			showTextFormattingMenu,
@@ -428,6 +447,8 @@ export default {
 			editingType,
 			sideBarFilterMap,
 			ticketSideBarFilter,
+			showCannedResponsesDialog,
+			tempMessage
 		}
 	},
 	resources: {
@@ -591,6 +612,11 @@ export default {
 		},
 		getNextTicket() {},
 		getPreviousTicket() {},
+
+		getMessage(message){
+			this.$refs.tempMessage=message
+			this.content=this.$refs.tempMessage
+		},
 	},
 }
 </script>

--- a/desk/src/pages/desk/settings/canned_response/CannedResponse.vue
+++ b/desk/src/pages/desk/settings/canned_response/CannedResponse.vue
@@ -1,0 +1,24 @@
+<template>
+	<div class="flex flex-col">
+		<CannedResponseInfo
+			class="shrink-0 border-r border-[#F4F5F6]"
+			:canned_response="canned_responseId"
+		/>
+	</div>
+</template>
+
+<script>
+import CannedResponseInfo from "@/components/desk/settings/canned_responses/CannedResponseInfo.vue"
+export default {
+	name: "CannedResponse",
+	props: ["canned_responseId"],
+	components: {
+    CannedResponseInfo
+},
+	setup() {},
+	mounted() {
+		this.$event.emit("set-selected-setting", "CannedResponses")
+		this.$event.emit("show-top-panel-actions-settings", "CannedResponse")
+	},
+}
+</script>

--- a/desk/src/pages/desk/settings/canned_response/CannedResponses.vue
+++ b/desk/src/pages/desk/settings/canned_response/CannedResponses.vue
@@ -1,0 +1,104 @@
+<template>
+	<div class="mt-[9px]">
+		<ListManager
+			ref="listManager"
+			class="px-[16px]"
+			:options="{
+				doctype: 'Canned Response',
+				fields: ['title','owner'],
+				limit: 20,
+			}"
+			@selection="
+				(selectedItems) => {
+					if (Object.keys(selectedItems).length > 0) {
+						$event.emit(
+							'show-top-panel-actions-settings',
+							'Canned Responses Bulk'
+						)
+					} else {
+						$event.emit('show-top-panel-actions-settings', 'CannedResponses')
+					}
+				}
+			"
+		>
+			<template #body="{ manager }">
+				<CannedResponseList :manager="manager" />
+			</template>
+		</ListManager>
+		<AddNewCannedResponsesDialog
+			:show="showNewCannedResponsesDialog"
+			@close="
+				() => {
+					showNewCannedResponsesDialog = false
+					$refs.listManager.manager.reload()
+					$router.go()
+				}
+			"
+		/>
+	</div>
+</template>
+<script>
+import { inject, ref } from "vue"
+import CannedResponseList from "@/components/desk/settings/canned_responses/CannedResponseList.vue"
+import ListManager from "@/components/global/ListManager.vue"
+import AddNewCannedResponsesDialog from "@/components/desk/global/AddNewCannedResponsesDialog.vue"
+export default {
+	name: "Canned Responses",
+	components: {
+    CannedResponseList,
+    ListManager,
+    AddNewCannedResponsesDialog
+},
+	setup() {
+		const viewportWidth = inject("viewportWidth")
+		const showNewCannedResponsesDialog = ref(false)
+		return {
+			viewportWidth,
+			showNewCannedResponsesDialog,
+		}
+	},
+	mounted() {
+		// this.$event.emit("set-selected-setting", "CannedResponses")
+		this.$event.emit("show-top-panel-actions-settings", "CannedResponses")
+		this.$event.on("show-new-canned_response-dialog", () => {
+			this.showNewCannedResponsesDialog = true
+		})
+		this.$event.on("delete-selected-canned_responses", () => {
+			this.$resources.bulk_delete_responses.submit({
+				items: Object.keys(
+					this.$refs.listManager.manager.selectedItems
+				),
+				doctype: "Canned Response",
+			})
+		})
+	},
+	unmounted() {
+		this.$event.off("show-new-canned_response-dialog")
+		this.$event.off("delete-selected-canned_responses")
+	},
+	resources: {
+		bulk_delete_responses() {
+			return {
+				method: "frappedesk.api.doc.delete_items",
+				onSuccess: () => {
+					this.$router.go()
+
+				},
+				onError: (err) => {
+					this.$refs.listManager.manager.reload()
+					this.$toast({
+						title: "Error while deleting canned responses",
+						text: err,
+						customIcon: "circle-check",
+						appearance: "success",
+					})
+					this.$event.emit(
+						"show-top-panel-actions-settings",
+						"CannedResponses"
+					)
+				},
+			}
+		},
+	},
+}
+</script>

--- a/desk/src/pages/desk/settings/canned_response/CannedResponses.vue
+++ b/desk/src/pages/desk/settings/canned_response/CannedResponses.vue
@@ -58,7 +58,7 @@ export default {
 		}
 	},
 	mounted() {
-		// this.$event.emit("set-selected-setting", "CannedResponses")
+		this.$event.emit("set-selected-setting", "Canned Responses")
 		this.$event.emit("show-top-panel-actions-settings", "CannedResponses")
 		this.$event.on("show-new-canned_response-dialog", () => {
 			this.showNewCannedResponsesDialog = true

--- a/desk/src/router.js
+++ b/desk/src/router.js
@@ -193,6 +193,19 @@ const routes = [
 						props: true,
 					},
 					{
+						path: "canned_response",
+						name: "CannedResponses",
+						component: () =>
+							import("@/pages/desk/settings/canned_response/CannedResponses.vue"),
+					},
+					{
+						path: "canned_responses/:canned_responseId",
+						name: "CannedResponse",
+						component: () =>
+							import("@/pages/desk/settings/canned_response/CannedResponse.vue"),
+						props: true,
+					},
+					{
 						path: "emails",
 						name: "Emails",
 						component: () =>

--- a/frappedesk/api/cannedResponse.py
+++ b/frappedesk/api/cannedResponse.py
@@ -1,0 +1,11 @@
+import frappe
+
+@frappe.whitelist()
+
+def get_canned_response(title=None):
+    if title==None:
+        response_list=frappe.db.get_list("Canned Response",fields=['name','title','message'])
+    else:
+        response_list=frappe.db.get_list("Canned Response",fields=['name','title','message'],filters={'title':['like','%{}%'.format(title)]})
+
+    return response_list

--- a/frappedesk/frappedesk/doctype/canned_response/canned_response.js
+++ b/frappedesk/frappedesk/doctype/canned_response/canned_response.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Canned Response', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappedesk/frappedesk/doctype/canned_response/canned_response.json
+++ b/frappedesk/frappedesk/doctype/canned_response/canned_response.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:title",
+ "creation": "2022-11-03 17:19:47.135176",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "message"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "unique": 1
+  },
+  {
+   "fieldname": "message",
+   "fieldtype": "Text Editor",
+   "label": "Message"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-11-03 17:20:21.807681",
+ "modified_by": "Administrator",
+ "module": "FrappeDesk",
+ "name": "Canned Response",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappedesk/frappedesk/doctype/canned_response/canned_response.py
+++ b/frappedesk/frappedesk/doctype/canned_response/canned_response.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class CannedResponse(Document):
+	pass

--- a/frappedesk/frappedesk/doctype/canned_response/test_canned_response.py
+++ b/frappedesk/frappedesk/doctype/canned_response/test_canned_response.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCannedResponse(FrappeTestCase):
+	pass


### PR DESCRIPTION
This implements canned response feature in Frappe Desk. 

**Key features added:**
1. Ability to manage canned responses from settings.
2. Ability quickly add canned responses when responding to tickets.
3. Ability to search and filter canned responses. 

Feature is based on UI and details provided by @harshit-30 

**Known Issues:**
1. Need to improve the settings sidebar to accommodate longer menu items.
2. Popup dialogs that is implemented for add new canned response and the one from which you pick a canned response can be sized better.
3. Default text size & margins  in Tiptap editor needs attention. 
