### PR TITLE
Add --watch for automatic build 

### DIFF
--- a/desk/package.json
+++ b/desk/package.json
@@ -6,6 +6,7 @@
 		"dev": "vite",
 		"preview": "vite preview",
 		"build": "vite build --base=/assets/frappedesk/desk/ && yarn copy-html-entry",
+		"watch": "vite build --watch --base=/assets/frappedesk/desk/ && yarn copy-html-entry",
 		"serve": "vite preview",
 		"copy-html-entry": "cp ../frappedesk/public/desk/index.html ../frappedesk/www/frappedesk/index.html"
 	},


### PR DESCRIPTION
@kamaljohnson Currently we need to run `yarn build` in desk directory to see changes made in `Vue` app within the running frappe app.  Do review this PR and merge if you agree with this approach.

```
"scripts": {
	....
		"watch": "vite build --watch --base=/assets/frappedesk/desk/ && yarn copy-html-entry",
	....
	},
```