### PR TITLE
fix: remove multiple reference of prettierrc.json config

### DIFF
--- a/desk/.prettierrc.json
+++ b/desk/.prettierrc.json
@@ -1,4 +1,0 @@
-{
-	"semi": false,
-	"singleQuote": true
-}


### PR DESCRIPTION
Fixed code formatting not working in vscode due to multiple reference of .prettierrc.json file