### PR TITLE
feat: add `read` indication in ticket list row

### DIFF
--- a/desk/src/pages/desk/Tickets.vue
+++ b/desk/src/pages/desk/Tickets.vue
@@ -97,6 +97,9 @@
 							}"
 							role="button"
 							class="line-clamp-1 hover:text-gray-900 text-gray-600"
+							:class="{
+								'font-semibold text-gray-900': !row._seen,
+							}"
 						>
 							{{ value }}
 						</router-link>


### PR DESCRIPTION
Tickets that are not read have their subject bold and darkened

### Before
<img width="884" alt="image" src="https://user-images.githubusercontent.com/22856401/201030537-066d020e-9814-43a4-8367-a6edbd84aceb.png">

### After
<img width="884" alt="image" src="https://user-images.githubusercontent.com/22856401/201030089-128f99f9-11f1-42b4-a6ae-2c7dc58aff85.png">
