### PR TITLE
fix: wrong tickets highlighted as read issue

### DIFF
--- a/desk/src/pages/desk/Tickets.vue
+++ b/desk/src/pages/desk/Tickets.vue
@@ -98,7 +98,9 @@
 							role="button"
 							class="line-clamp-1 hover:text-gray-900 text-gray-600"
 							:class="{
-								'font-semibold text-gray-900': !row._seen,
+								'font-semibold text-gray-900': !(
+									JSON.parse(row._seen) || []
+								).includes(user.user),
 							}"
 						>
 							{{ value }}


### PR DESCRIPTION
### Before:
All the tickets which were seen by any user were highlighted

### Fix:
Only the tickets which are not read/seen by the viewing agent will be highlighted