### PR TITLE
remove extra hover space from f-desk logo

### DIFF
--- a/desk/src/components/desk/SideBarMenu.vue
+++ b/desk/src/components/desk/SideBarMenu.vue
@@ -3,7 +3,7 @@
 		class="flex flex-col border-r pt-[23px]"
 		:style="{ height: viewportWidth > 768 ? 'calc(100vh)' : null }"
 	>
-		<div class="mb-[38.4px] cursor-pointer pl-[22px]">
+		<div class="mb-[38.4px] cursor-pointer pl-[22px] pr-[22px] w-fit">
 			<CustomIcons
 				name="frappedesk"
 				class="h-[16.6px] w-[67.84px]"


### PR DESCRIPTION
Removed extra hover space and added padding to right for consistency

If having the cursor only on logo is needed, i'll update to that. 

Fixes - #371

[Screencast from 14-11-22 06:34:53 PM IST.webm](https://user-images.githubusercontent.com/95645706/201667560-1767f88f-fedc-4212-85c6-3f471cb9939e.webm)
