### PR TITLE
Update regex for agent email addresses

### DIFF
--- a/desk/src/components/desk/global/AddNewAgentsDialog.vue
+++ b/desk/src/components/desk/global/AddNewAgentsDialog.vue
@@ -109,7 +109,7 @@ export default {
 	},
 	methods: {
 		testEmailRegex(val) {
-			let emailRegex = /^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/
+			let emailRegex = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
 			return emailRegex.test(val)
 		},
 		onSearchInputChange(val) {


### PR DESCRIPTION
Support agent email addresses with multiple subdomains (e.g., user@some.domain.com) and which start with numbers (e.g., user@6ceed.com)