### PR TITLE
fix:  assignment rule user list index out of range issue

### DIFF
--- a/frappedesk/frappedesk/doctype/agent/agent.py
+++ b/frappedesk/frappedesk/doctype/agent/agent.py
@@ -94,6 +94,7 @@ class Agent(Document):
 
 				user_doc = frappe.get_doc({"doctype": "Assignment Rule User", "user": self.user})
 				rule_doc.append("users", user_doc)
+				rule_doc.disabled = False  # enable the rule if it is disabled
 				rule_doc.save(ignore_permissions=True)
 
 	def remove_from_support_rotations(self, group=None):
@@ -129,6 +130,8 @@ class Agent(Document):
 			if rule_doc.users and len(rule_doc.users) > 0:
 				for user in rule_doc.users:
 					if user.user == self.user:
+						if len(rule_doc.users) == 1:
+							rule_doc.disabled = True  # disable the rule if there are no users left
 						rule_doc.remove(user)
 						rule_doc.save()
 

--- a/frappedesk/frappedesk/doctype/agent_group/agent_group.py
+++ b/frappedesk/frappedesk/doctype/agent_group/agent_group.py
@@ -43,6 +43,7 @@ class AgentGroup(Document):
 		rule_doc.document_type = "Ticket"
 		rule_doc.assign_condition = f"status == 'Open' and agent_group == '{self.name}'"
 		rule_doc.priority = 1
+		rule_doc.disabled = True  # Disable the rule by default, when agents are added to the group, the rule will be enabled
 
 		for day in [
 			"Monday",

--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.py
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.py
@@ -28,6 +28,7 @@ class FrappeDeskSettings(Document):
 		rule_doc.document_type = "Ticket"
 		rule_doc.assign_condition = f"status == 'Open'"
 		rule_doc.priority = 0
+		rule_doc.disabled = True  # Disable the rule by default, when agents are added to the group, the rule will be enabled
 
 		for day in [
 			"Monday",

--- a/frappedesk/patches.txt
+++ b/frappedesk/patches.txt
@@ -30,4 +30,5 @@ frappedesk.patches.set_assignment_rule_field_of_agent_groups
 frappedesk.patches.add_base_assignment_rule_to_frappe_desk_settings
 frappedesk.patches.add_all_tickets_system_preset_filter
 frappedesk.patches.set_home_page_to_kb #2
+frappedesk.patches.mark_assignment_rule_disabled_if_no_agents_is_active
 

--- a/frappedesk/patches/mark_assignment_rule_disabled_if_no_agents_is_active.py
+++ b/frappedesk/patches/mark_assignment_rule_disabled_if_no_agents_is_active.py
@@ -1,0 +1,40 @@
+import frappe
+
+
+def execute():
+	# Disable the base support rotation rule if no agents are active
+	base_support_rotation_rule = frappe.get_doc(
+		"Frappe Desk Settings"
+	).get_base_support_rotation()
+	if frappe.db.count("Agent", {"is_active": 1}) == 0:
+		base_support_rotation_rule_doc = frappe.get_doc(
+			"Assignment Rule", base_support_rotation_rule
+		)
+		base_support_rotation_rule_doc.disabled = 1
+		base_support_rotation_rule_doc.save(ignore_permissions=True)
+
+	# Disable the group support rotation rule, if no agents are active in an agent group
+	# Get all agent group docs
+	all_agent_groups = frappe.get_all(
+		"Agent Group", fields=["name"], limit_page_length=9999
+	)
+	all_agent_group_docs = [
+		frappe.get_doc("Agent Group", group.name) for group in all_agent_groups
+	]
+
+	# Check if for each agent group, there are active agents, if not, disable the group support rotation rule
+	for agent_group_doc in all_agent_group_docs:
+		# Get the group support rotation rule
+		agent_group_assigmnent_rule_doc = frappe.get_doc(
+			"Assignment Rule", agent_group_doc.get_assignment_rule()
+		)
+		# filter out agnets that are not active and has the current agent group in the agent group list
+		filters = [
+			["Agent Group Item", "agent_group", "=", agent_group_doc.name],
+			["Agent", "is_active", "=", 1],
+		]
+		if frappe.db.count("Agent", filters=filters) == 0:
+			agent_group_assigmnent_rule_doc.disabled = 1
+		else:
+			agent_group_assigmnent_rule_doc.disabled = 0
+		agent_group_assigmnent_rule_doc.save(ignore_permissions=True)

--- a/frappedesk/setup/install.py
+++ b/frappedesk/setup/install.py
@@ -280,35 +280,8 @@ def update_agent_role_permissions():
 
 
 def add_default_assignment_rule():
-	rule_doc = frappe.new_doc("Assignment Rule")
-	rule_doc.name = "Support Rotation"
-	rule_doc.document_type = "Ticket"
-	rule_doc.description = "Automatic Ticket Assignment"
-	rule_doc.assign_condition = "status == 'Open'"
-	rule_doc.rule = "Round Robin"
-	rule_doc.priority = 0
-
-	for agent in frappe.get_all("Agent", fields=["user"]):
-		user_doc = frappe.get_doc({"doctype": "Assignment Rule User", "user": agent.user})
-		rule_doc.append("users", user_doc)
-
-	for day in [
-		"Monday",
-		"Tuesday",
-		"Wednesday",
-		"Thursday",
-		"Friday",
-		"Saturday",
-		"Sunday",
-	]:
-		day_doc = frappe.get_doc({"doctype": "Assignment Rule Day", "day": day})
-		rule_doc.append("assignment_days", day_doc)
-
-	rule_doc.insert()
-
 	support_settings = frappe.get_doc("Frappe Desk Settings")
-	support_settings.base_support_rotation = rule_doc.name
-	support_settings.save()
+	support_settings.create_base_support_rotation()
 
 
 def add_system_preset_filters():


### PR DESCRIPTION
Resolves #823

What this does:

- marks the assignment rule as disabled if no active agents belong to the rule
- marks assignment rules related to agent groups as disabled by default, which gets enabled when agents are added to the group
- the base support rotation rule is also marked as disabled by default, and gets enabled only if there is any active agents preset

Added patches to disable / enable existing assignment rules