### PR TITLE
fix: ui in kb articles

### DIFF
--- a/desk/src/components/desk/kb/ArticleTitleAndContent.vue
+++ b/desk/src/components/desk/kb/ArticleTitleAndContent.vue
@@ -1,7 +1,9 @@
 <template>
-	<div class="flex h-full flex-col space-y-[16px]">
+	<div
+		class="flex h-full flex-col space-y-[16px] rounded-[8px] border shadow-sm p-[32px]"
+	>
 		<div>
-			<div v-if="editMode" class="flex flex-col">
+			<div v-if="editMode" class="flex flex-col edit_title max-w-full">
 				<Input
 					label="Title"
 					type="text"
@@ -10,7 +12,8 @@
 				/>
 				<ErrorMessage :message="articleInputErrors.title" />
 			</div>
-			<div v-else class="text-[24px] font-semibold">
+
+			<div v-else class="text-[24px] font-semibold title max-w-full border-b pb-[16px] mb-[10px]">
 				{{ article.title }}
 			</div>
 		</div>
@@ -22,32 +25,37 @@
 				>
 					Content
 				</div>
-				<TextEditor
-					:class="editMode ? 'bg-gray-100' : ''"
-					ref="textEditor"
-					:editor-class="
-						!editable
-							? 'flex flex-col'
-							: editMode
-							? 'min-h-[20rem] overflow-y-auto max-h-[73vh] w-full px-3'
-							: 'min-h-[20rem] overflow-y-auto max-h-[85vh]'
-					"
-					:content="article.content"
-					:starterkit-options="{
-						heading: { levels: [2, 3, 4, 5, 6] },
-					}"
-					@change="onContentInput"
-					:editable="editMode"
-				>
-					<template v-slot:top>
-						<div v-if="editMode">
-							<TextEditorFixedMenu
-								class="m-3 overflow-x-auto"
-								:buttons="textEditorMenuButtons"
-							/>
-						</div>
-					</template>
-				</TextEditor>
+
+				<div class="max-w-full flex overflow-y-auto px-2 h-full">
+					<TextEditor
+						:class="editMode ? 'bg-gray-100' : ''"
+						ref="textEditor"
+						class="edit_body max-w-full"
+						:editor-class="
+							!editable
+								? 'flex flex-col'
+								: editMode
+								? 'min-h-[20rem] max-h-[73vh] w-full px-3 max-w-full'
+								: 'min-h-[20rem] max-h-[85vh] max-w-full w-full h-full'
+						"
+						:content="article.content"
+						:starterkit-options="{
+							heading: { levels: [2, 3, 4, 5, 6] },
+						}"
+						@change="onContentInput"
+						:editable="editMode"
+					>
+						<template v-slot:top>
+							<div v-if="editMode">
+								<TextEditorFixedMenu
+									class="m-3 overflow-x-auto"
+									:buttons="textEditorMenuButtons"
+								/>
+							</div>
+						</template>
+					</TextEditor>
+				</div>
+
 				<ErrorMessage :message="articleInputErrors.content" />
 			</div>
 		</div>


### PR DESCRIPTION
Kb single article page and edit page both had UI issues. This PR is for quick fix of the UI. A full clean-up of page can be done with designer input in future. 

## Screenshots of UI before and after the fix

>Article View - Before
<img width="1140" alt="Screenshot 2022-12-20 at 1 21 02 AM" src="https://user-images.githubusercontent.com/246454/208529772-f92bf975-74fe-4c08-8742-341335feed6f.png">

>Article View - After
<img width="1137" alt="Screenshot 2022-12-20 at 3 03 40 AM" src="https://user-images.githubusercontent.com/246454/208529835-5ce648a1-6f70-418c-9a76-79caca90303e.png">

>Article Edit - Before
<img width="1065" alt="Screenshot 2022-12-20 at 1 20 12 AM" src="https://user-images.githubusercontent.com/246454/208529942-6970543a-d54b-43cc-8245-fe4c1614a47e.png">

>Article Edit - After
<img width="1138" alt="Screenshot 2022-12-20 at 3 03 58 AM" src="https://user-images.githubusercontent.com/246454/208530318-5c94225e-708e-4a97-a2bb-d385f5c67d70.png">



