### PR TITLE
fix: contact name issue in info-panel

### DIFF
--- a/desk/src/components/desk/ticket/InfoPanel.vue
+++ b/desk/src/components/desk/ticket/InfoPanel.vue
@@ -262,7 +262,7 @@
 										index < maxCount
 											? `/frappedesk/tickets/${_ticket.name}`
 											: `/frappedesk/tickets/?contact=${JSON.stringify(
-													['is', contact.name]
+													['is', ticket.contact]
 											  )}`
 									"
 									class="text-[12px] rounded"


### PR DESCRIPTION
Before: clicking on `Open Tickets` drop panel throw some error and did not show the tickets list
After: this issue is fixed, and the ticket list can be seen when clicked

<img width="273" alt="image" src="https://user-images.githubusercontent.com/22856401/210053408-815c2551-ee71-4b20-8d98-402efc2d553b.png">
