### PR TITLE
feat: add default ticket type, in fd settings, with `Question` as default one

### DIFF
--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
@@ -11,6 +11,7 @@
 		"column_break_4",
 		"helpdesk_name",
 		"issues_sb",
+		"default_ticket_type",
 		"close_issue_after_days",
 		"portal_sb",
 		"get_started_sections",
@@ -182,11 +183,17 @@
 			"fieldname": "suggest_articles_in_new_ticket_page",
 			"fieldtype": "Check",
 			"label": "Suggest Articles in New TIcket Page"
+		},
+		{
+			"fieldname": "default_ticket_type",
+			"fieldtype": "Link",
+			"label": "Default Ticket Type",
+			"options": "Ticket Type"
 		}
 	],
 	"issingle": 1,
 	"links": [],
-	"modified": "2022-12-01 14:54:43.250637",
+	"modified": "2022-12-30 14:45:58.112267",
 	"modified_by": "Administrator",
 	"module": "FrappeDesk",
 	"name": "Frappe Desk Settings",

--- a/frappedesk/frappedesk/doctype/ticket/ticket.py
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.py
@@ -34,6 +34,8 @@ class Ticket(Document):
 		self.set_contact(self.raised_by)
 
 	def before_insert(self):
+		if not self.ticket_type:
+			self.ticket_type = frappe.get_doc("Frappe Desk Settings").default_ticket_type
 		self.update_priority_based_on_ticket_type()
 
 	def after_insert(self):

--- a/frappedesk/patches.txt
+++ b/frappedesk/patches.txt
@@ -32,3 +32,4 @@ frappedesk.patches.add_all_tickets_system_preset_filter
 frappedesk.patches.set_home_page_to_kb #2
 frappedesk.patches.mark_assignment_rule_disabled_if_no_agents_is_active
 frappedesk.patches.remove_support_redirects_from_website_settings
+frappedesk.patches.add_default_ticket_type

--- a/frappedesk/patches/add_default_ticket_type.py
+++ b/frappedesk/patches/add_default_ticket_type.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	settings = frappe.get_doc("Frappe Desk Settings")
+	if frappe.db.exists("Ticket Type", "Question"):
+		settings.default_ticket_type = "Question"
+		settings.save()

--- a/frappedesk/setup/install.py
+++ b/frappedesk/setup/install.py
@@ -204,6 +204,10 @@ def add_default_ticket_types():
 			type_doc.name = type
 			type_doc.insert()
 
+	settings = frappe.get_doc("Frappe Desk Settings")
+	settings.default_ticket_type = "Question"
+	settings.save()
+
 
 def add_default_ticket_priorities():
 	ticket_priorities = ["Low", "Medium", "High", "Urgent"]


### PR DESCRIPTION
Resolves #901 

this can be configured from `Frappe Desk Settings` > `Default Ticket Type`
by default its set a `Question`

added patch to set the default value for old users